### PR TITLE
Increase max wait before timeout exceptions thrown

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -27,7 +27,8 @@ driver = webdriver.PhantomJS()
 driver.implicitly_wait(10)
 
 # Create our standard waitable...
-wait = WebDriverWait(driver, 5)
+# At most, wait 30 seconds before exploding with a Timeout exception.
+wait = WebDriverWait(driver, 30)
 
 # Make sure the browser process is shutdown when we exit,
 # whether we die from an error later or not.

--- a/scraper.py
+++ b/scraper.py
@@ -15,7 +15,6 @@ from urlparse import urljoin
 import scraperwiki
 # Ensure our cleanup gets called
 import atexit
-import os
 
 # Consts
 url = "http://datracker.portstephens.nsw.gov.au/"


### PR DESCRIPTION
As it says in the comment, allowing 5 seconds for the browser to fetch and render the results was probably a little optimistic.

This patch bumps up the wait times before any panicking happens. 
